### PR TITLE
Update bounce_driver.class.php

### DIFF
--- a/bounce_driver.class.php
+++ b/bounce_driver.class.php
@@ -511,7 +511,7 @@ class BounceHandler{
         }
         // special formatting
         $hash['Received']= @explode('|', $hash['Received']);
-        $hash['Subject'] = isset($hash['Subject']) ? : '';
+        $hash['Subject'] = isset($hash['Subject']) ? $hash['Subject'] : '';
         return $hash;
     }
 


### PR DESCRIPTION
```
    // This looks like a bug...
    //    $hash['Subject'] = isset($hash['Subject']) ? : '';
    // Would set $hash['Subject'] to 1 if $hash['Subject'] was set or an empty string otherwise
    // I can't think of/find any reason why it should do this... - JAP
    //$hash['Subject'] = isset($hash['Subject']) ? : '';
```
